### PR TITLE
Remove unnecessary console.log

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -138,7 +138,6 @@ export function exportToJSON(vc){
         };
 
         for(let property in node.definition.properties){
-            console.log(">>>",property);
             node.properties[property] = processor[property];
         }
 


### PR DESCRIPTION
This appears on every call of `VideoContext.exportToJSON()`.