### PR TITLE
swap to https link for purecss on in github pages site

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<title>VideoContext</title>
-	<link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
+	<link rel="stylesheet" href="https://unpkg.com/purecss@0.6.2/build/pure-min.css" integrity="sha384-UQiGfs9ICog+LwheBSRCt1o5cbyKIHbwjWscjemyBMT9YCUMZffs6UqUTd0hObXD" crossorigin="anonymous">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<style type="text/css">
 	.header {


### PR DESCRIPTION
Went to visit the github pages and noticed purecss isn't loading properly because of the protocol mistmatch - this PR just updates with the latest link from their official site.

![image](https://cloud.githubusercontent.com/assets/11612724/25783698/5a77379c-3361-11e7-8fa5-400ccab4cfeb.png)

Fantastic talk at JSConf by the way 🙌  the library is pretty incredible.