### PR TITLE
On mobile this pause would sometimes happen straight after playing an…

### DIFF
--- a/src/videoelementcache.js
+++ b/src/videoelementcache.js
@@ -32,7 +32,6 @@ class VideoElementCache {
             for(let element of this._elements){
                 try {
                     element.play().then(()=>{
-                        element.pause();
                     }, (e)=>{
                         if (e.name !== "NotSupportedError")throw(e);
                     });


### PR DESCRIPTION
… element. Removing it fixes that issue