### PR TITLE
Fix unresolved duration variable.

### DIFF
--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -253,7 +253,7 @@ export default class VideoContext{
     *
     */
     set currentTime(currentTime){
-        if (currentTime < this._duration && this._state === VideoContext.STATE.ENDED) this._state = VideoContext.STATE.PAUSED;
+        if (currentTime < this.duration && this._state === VideoContext.STATE.ENDED) this._state = VideoContext.STATE.PAUSED;
 
         if (typeof currentTime === "string" || currentTime instanceof String){
             currentTime = parseFloat(currentTime);


### PR DESCRIPTION
The _duration variable should be duration.

This resolves the case where state is not maintained when setting currentTime after video playback has ended.