### PR TITLE
Documentation hosting added

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ npm run doc
 ```
 The documentation will be generated in the "./doc" folder of the repository.
 
+The documentation is also hosted at https://doc.esdoc.org/github.com/bbc/VideoContext/.
+
+
 ## Node Types
 There are a number of different types of nodes which can be used in the VideoContexts processing graph. Here's a quick list of each one, following that is a more in-depth discussion of each type.
 


### PR DESCRIPTION
### What Does This PR Do?

Adds hosting for the ESDoc-generated documentation, using ESDoc's hosting service: https://doc.esdoc.org/. The `README.md` has been updated to include the url: https://doc.esdoc.org/github.com/bbc/VideoContext/

_N.B. It's worth noting that because the docs are automatically generated they aren't necessarily structured in the most readable format, and they include a lot of detail that we'd choose to omit if we hand-wrote them. However, to create a docs site from scratch is probably too much effort for the current scope of work.