### PR TITLE
Fix image unload method

### DIFF
--- a/src/SourceNodes/imagenode.js
+++ b/src/SourceNodes/imagenode.js
@@ -53,7 +53,7 @@ class ImageNode extends SourceNode {
 
     _unload() {
         super._unload();
-        if (this._isResponsibleForElementLifeCycle) {
+        if (this._isResponsibleForElementLifeCycle && this._element !== undefined) {
             this._element.src = "";
             this._element.onerror = undefined;
             this._element = undefined;


### PR DESCRIPTION
The image node's `_element` property isn't created until `_load` is called. If the node is unloaded with `_unload` before being loaded it will currently throw an exception.

This change adds a check to see if the element exists before attempting to modify it.