### PR TITLE
Dispatch "stalled" event when media is buffering

### DIFF
--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -221,6 +221,14 @@ class MediaNode extends SourceNode {
         this._unload();
     }
 
+    get _buffering() {
+        if (this._element) {
+            return this._element.readyState < HTMLMediaElement.HAVE_FUTURE_DATA;
+        }
+
+        return false;
+    }
+
     destroy() {
         if (this._element) this._element.pause();
         super.destroy();

--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -63,6 +63,19 @@ class MediaNode extends SourceNode {
         return this._elementURL;
     }
 
+    /**
+     * @property {Boolean}
+     * @summary - Check if the element is waiting on the network to continue playback
+     */
+
+    get _buffering() {
+        if (this._element) {
+            return this._element.readyState < HTMLMediaElement.HAVE_FUTURE_DATA;
+        }
+
+        return false;
+    }
+
     set volume(volume) {
         this._volume = volume;
         if (this._element !== undefined) this._element.volume = this._volume;
@@ -219,14 +232,6 @@ class MediaNode extends SourceNode {
             this._isElementPlaying = false;
         }
         this._unload();
-    }
-
-    get _buffering() {
-        if (this._element) {
-            return this._element.readyState < HTMLMediaElement.HAVE_FUTURE_DATA;
-        }
-
-        return false;
     }
 
     destroy() {

--- a/src/SourceNodes/sourcenode.js
+++ b/src/SourceNodes/sourcenode.js
@@ -338,6 +338,9 @@ class SourceNode extends GraphNode {
     }
 
     _isReady() {
+        if (this._buffering) {
+            return false;
+        }
         if (
             this._state === STATE.playing ||
             this._state === STATE.paused ||


### PR DESCRIPTION
This change modifies the stalled event so that it is fired when waiting on the network for data (buffering).

Changes: 
* Add `buffering` property to the `MediaNode` based on the `HTMLMediaElement`'s `readyState`
* `SourceNode` checks its `buffering` property when reporting readiness.