### PR TITLE
always read volume from mediaNode._attributes.volume

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
 branches:
   only:
     - master
+    - develop
 jobs:
     include:
       - stage: deploy

--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -23,7 +23,6 @@ class MediaNode extends SourceNode {
         this._globalPlaybackRate = globalPlaybackRate;
         this._mediaElementCache = mediaElementCache;
         this._playbackRate = 1.0;
-        this._volume = 1.0;
         this._playbackRateUpdated = true;
         this._attributes = attributes;
         this._loopElement = false;
@@ -77,8 +76,8 @@ class MediaNode extends SourceNode {
     }
 
     set volume(volume) {
-        this._volume = volume;
-        if (this._element !== undefined) this._element.volume = this._volume;
+        this._attributes.volume = volume;
+        if (this._element !== undefined) this._element.volume = this._attributes.volume;
     }
 
     _load() {
@@ -118,7 +117,7 @@ class MediaNode extends SourceNode {
                 this._element.setAttribute("playsinline", "");
                 this._playbackRateUpdated = true;
             }
-            this._element.volume = this._volume;
+            this._element.volume = this._attributes.volume;
             if (window.MediaStream !== undefined && this._elementURL instanceof MediaStream) {
                 this._element.srcObject = this._elementURL;
             } else {

--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -15,7 +15,7 @@ class MediaNode extends SourceNode {
         sourceOffset = 0,
         preloadTime = 4,
         mediaElementCache = undefined,
-        attributes = { volume: 1.0 }
+        attributes = {}
     ) {
         super(src, gl, renderGraph, currentTime);
         this._preloadTime = preloadTime;
@@ -24,7 +24,7 @@ class MediaNode extends SourceNode {
         this._mediaElementCache = mediaElementCache;
         this._playbackRate = 1.0;
         this._playbackRateUpdated = true;
-        this._attributes = attributes;
+        this._attributes = Object.assign({ volume: 1.0 }, attributes);
         this._loopElement = false;
         this._isElementPlaying = false;
         if (this._attributes.loop) {

--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -15,7 +15,7 @@ class MediaNode extends SourceNode {
         sourceOffset = 0,
         preloadTime = 4,
         mediaElementCache = undefined,
-        attributes = {}
+        attributes = { volume: 1.0 }
     ) {
         super(src, gl, renderGraph, currentTime);
         this._preloadTime = preloadTime;

--- a/test/integration/medianode.test.js
+++ b/test/integration/medianode.test.js
@@ -18,6 +18,7 @@ const nodeFactory = (vidCtx, attr = {}) => {
 
 beforeEach(() => {
     const canvas = new HTMLCanvasElement(500, 500);
+    // Don't useVideoElementCache as unnecessary and would need to be patched with a mock
     ctx = new VideoContext(canvas, undefined, { useVideoElementCache: false });
 });
 

--- a/test/integration/medianode.test.js
+++ b/test/integration/medianode.test.js
@@ -1,0 +1,61 @@
+import VideoContext from "../../src/videocontext";
+
+let ctx;
+require("webgl-mock");
+
+const nodeFactory = (vidCtx, attr = {}) => {
+    const element = {
+        play: jest.fn(),
+        pause: jest.fn()
+    };
+    const node = vidCtx.video(element, undefined, undefined, attr);
+    // some sane defaults
+    // node should play from the start
+    node.start(0);
+    node.stop(10);
+    return { node, element };
+};
+
+beforeEach(() => {
+    const canvas = new HTMLCanvasElement(500, 500);
+    ctx = new VideoContext(canvas, undefined, { useVideoElementCache: false });
+});
+
+describe("medianode", () => {
+    describe("attributes", () => {
+        it("volume setter sets volume on element", () => {
+            const { element, node } = nodeFactory(ctx);
+            node.volume = 0.5;
+            expect(element.volume).toBe(0.5);
+            node.volume = 1.5;
+            expect(element.volume).toBe(1.5);
+        });
+
+        it("should play with a default volume if volume attribute is not supplied", () => {
+            expect.assertions(3);
+
+            const { element } = nodeFactory(ctx);
+            expect(element.volume).toBe(undefined /* because our mock has no volume attr */);
+
+            // We want to trigger a load so that the node attributes will be applied to
+            // the video element.
+            // advance timeline 1s to do this
+            ctx.update(1);
+
+            expect(element.volume).not.toBe(undefined /* it will be a number now */);
+            expect(element.volume).toBeGreaterThan(-Infinity);
+        });
+
+        it("should set provided volume on update if volume attribute is supplied", () => {
+            const { element } = nodeFactory(ctx, { volume: 0.2 });
+            expect(element.volume).toBe(undefined /* because our mock has no volume attr */);
+
+            // We want to trigger a load so that the node attributes will be applied to
+            // the video element.
+            // advance timeline 1s to do this
+            ctx.update(1);
+
+            expect(element.volume).toBe(0.2);
+        });
+    });
+});

--- a/test/integration/medianode.test.js
+++ b/test/integration/medianode.test.js
@@ -3,6 +3,10 @@ import VideoContext from "../../src/videocontext";
 let ctx;
 require("webgl-mock");
 
+/*
+* creates a video node with provided attributes.
+* returns: the node instance and the mocked HTMLVideoElement which is controlled by the node
+*/
 const nodeFactory = (vidCtx, attr = {}) => {
     const element = {
         play: jest.fn(),
@@ -16,12 +20,21 @@ const nodeFactory = (vidCtx, attr = {}) => {
     return { node, element };
 };
 
+/*
+* create a fresh video context with mocked canvas for each test
+* don't useVideoElementCache as unnecessary for these tests and would need to be patched with a mock.
+*/
 beforeEach(() => {
     const canvas = new HTMLCanvasElement(500, 500);
-    // Don't useVideoElementCache as unnecessary and would need to be patched with a mock
     ctx = new VideoContext(canvas, undefined, { useVideoElementCache: false });
 });
 
+/*
+* These tests use nodeFactory to produce a video element and a controlling video node.
+* The tests check that interaction with the node effects the element as intended.
+* Some tested interactions require the node to have loaded. (eg updating element attributes)
+* We use the public ctx.update method to advance the videocontext timeline and trigger these updates
+*/
 describe("medianode", () => {
     describe("volume", () => {
         it("volume setter sets volume on element", () => {

--- a/test/integration/medianode.test.js
+++ b/test/integration/medianode.test.js
@@ -22,7 +22,7 @@ beforeEach(() => {
 });
 
 describe("medianode", () => {
-    describe("attributes", () => {
+    describe("volume", () => {
         it("volume setter sets volume on element", () => {
             const { element, node } = nodeFactory(ctx);
             node.volume = 0.5;
@@ -56,6 +56,21 @@ describe("medianode", () => {
             ctx.update(1);
 
             expect(element.volume).toBe(0.2);
+        });
+    });
+
+    describe("other attributes", () => {
+        it("should set generic attributes on node when update loop is run", () => {
+            const { element } = nodeFactory(ctx, { asdf: "great!" });
+            expect(element.asdf).toBe(undefined /* because our mock has no asdf attr */);
+
+            // We want to trigger a load so that the node attributes will be applied to
+            // the video element.
+            // advance timeline 1s to do this
+            ctx.update(1);
+
+            expect(element.asdf).toBe("great!");
+            expect(element.notasdf).toBe(undefined);
         });
     });
 });


### PR DESCRIPTION
Until now volume existed as two bits of state.
This commit favours the attributes object as the single source of truth.

### todo
This is a good opportunity to write some integration tests

- [x] test that on supplying no attributes it doesn't break (a default volume is set)
- [x] test that on setting the volume via the setter, this is still the case after a load

