### PR TITLE
Use "files" whitelist instead of .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-coverage
-docs

--- a/package.json
+++ b/package.json
@@ -68,5 +68,8 @@
     "webgl-mock": "^0.1.7",
     "webpack": "^4.10.2",
     "webpack-cli": "^3.0.1"
-  }
+  },
+  "files": [
+    "dist"
+  ]
 }


### PR DESCRIPTION

## why?

In the eyes of npm .npmignore replaces .gitignore.

This is hard to maintain as the gitignore is pretty much always a subset of the npmignore

Also, we'd rather whitelist than blacklist. There are many more things to exclude than include.

The package.json `files` field lets us to this.

see https://blog.npmjs.org/post/165769683050/publishing-what-you-mean-to-publish