### PR TITLE
Fix stripHash function to allow for URL query params

### DIFF
--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -152,8 +152,9 @@ class MediaNode extends SourceNode {
     _unload() {
         super._unload();
         if (this._isResponsibleForElementLifeCycle && this._element !== undefined) {
-            this._element.src = "";
+            this._element.removeAttribute("src");
             this._element.srcObject = undefined;
+            this._element.load();
             for (let key in this._attributes) {
                 this._element.removeAttribute(key);
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -850,3 +850,7 @@ export class UpdateablesManager {
         }
     }
 }
+
+export function mediaElementHasSource({ src, srcObject }) {
+    return !((src === "" || src === undefined) && srcObject == null);
+}

--- a/src/videoelementcache.js
+++ b/src/videoelementcache.js
@@ -1,8 +1,8 @@
 function stripHash(url) {
     if (url.port === "" || url.port === undefined) {
-        return `${url.protocol}//${url.hostname}${url.pathname}`;
+        return `${url.protocol}//${url.hostname}${url.pathname}${url.search}`;
     } else {
-        return `${url.protocol}//${url.hostname}:${url.port}${url.pathname}`;
+        return `${url.protocol}//${url.hostname}:${url.port}${url.pathname}${url.search}`;
     }
 }
 

--- a/src/videoelementcache.js
+++ b/src/videoelementcache.js
@@ -1,10 +1,4 @@
-function stripHash(url) {
-    if (url.port === "" || url.port === undefined) {
-        return `${url.protocol}//${url.hostname}${url.pathname}${url.search}`;
-    } else {
-        return `${url.protocol}//${url.hostname}:${url.port}${url.pathname}${url.search}`;
-    }
-}
+import { mediaElementHasSource } from "./utils";
 
 class VideoElementCache {
     constructor(cache_size = 3) {
@@ -21,7 +15,6 @@ class VideoElementCache {
         videoElement.setAttribute("crossorigin", "anonymous");
         videoElement.setAttribute("webkit-playsinline", "");
         videoElement.setAttribute("playsinline", "");
-        videoElement.src = "";
         return videoElement;
     }
 
@@ -47,13 +40,9 @@ class VideoElementCache {
         //Try and get an already intialised element.
         for (let element of this._elements) {
             // For some reason an uninitialised videoElement has its sr attribute set to the windows href. Hence the below check.
-            if (
-                (element.src === "" ||
-                    element.src === undefined ||
-                    element.src === stripHash(window.location)) &&
-                element.srcObject == null
-            )
+            if (!mediaElementHasSource(element)) {
                 return element;
+            }
         }
         //Fallback to creating a new element if non exists.
         console.debug(
@@ -73,12 +62,7 @@ class VideoElementCache {
         let count = 0;
         for (let element of this._elements) {
             // For some reason an uninitialised videoElement has its sr attribute set to the windows href. Hence the below check.
-            if (
-                (element.src === "" ||
-                    element.src === undefined ||
-                    element.src === stripHash(window.location)) &&
-                element.srcObject == null
-            )
+            if (!mediaElementHasSource(element))
                 count += 1;
         }
         return count;

--- a/test/unit/utils.spec.js
+++ b/test/unit/utils.spec.js
@@ -1,0 +1,40 @@
+import * as Utils from "../../src/utils.js";
+
+describe(`Utils`, () => {
+    describe(`mediaElementHasSource()`, () => {
+        it(`Should return true if the element has a src`, () => {
+            const mockMediaElement = { src: "http://bbc.co.uk" };
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(true);
+            mockMediaElement.src = "https://google.com";
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(true);
+            mockMediaElement.src = "fgdfgdfgdg";
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(true);
+            
+            delete mockMediaElement.src;
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(false);
+        });
+
+        it(`Should return true if the element has a srcObject`, () => {
+            const mockMediaElement = { srcObject: {} };
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(true);
+        });
+
+        it(`Should return false if the src is an empty string or undefined`, () => {
+            const mockMediaElement = { src: "" };
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(false);
+            mockMediaElement.src = undefined;
+            expect(Utils.mediaElementHasSource(mockMediaElement)).toBe(false);
+        });
+
+        it(`Should return false if the src and srcObject do not exist`, () => {
+            expect(Utils.mediaElementHasSource({})).toBe(false);
+        });
+
+        it(`Should throw given empty argument`, () => {
+            expect(() => (Utils.mediaElementHasSource())).toThrow();
+            expect(() => (Utils.mediaElementHasSource(null))).toThrow();
+            expect(() => (Utils.mediaElementHasSource(undefined))).toThrow();
+        });
+
+    });
+});


### PR DESCRIPTION
This issue currently causes some severe playback issues if you have query params in your page URL.

When a `mediaNode` attempts to `get` a media element from the `VideoElementCache`, the `get` method checks to see if the element has already been assigned a source.

There is a strange behaviour in the browser where the `src` property of the element is sometimes set to the current page's URL, so the method checks to see if the `src` is the same as the current page URL, sans the `hash` (as this can change without reloading the page).

Due to the query params not being included in the returned value of `stripHash`, this comparison will never return true if the current URL has query params, so `get` will never return the element as intended.