### PR TITLE
Change package.json main entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/bbc/VideoContext.git"
   },
   "license": "Apache-2.0",
-  "main": "dist/videocontext.js",
+  "browser": "dist/videocontext.js",
   "keywords": [
     "video",
     "context",


### PR DESCRIPTION
Hi,

This library is intended to be used client-side and NPM recommends to use the `browser` field instead of `main` in that specific case.

https://docs.npmjs.com/files/package.json#browser

Not 100% sure if that could have an impact on the build/release pipeline. So far my testing seemed fine.