### PR TITLE
Bugfix for alpha blending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.52.10",
+  "version": "0.54.0",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",
@@ -8,6 +8,7 @@
   },
   "license": "Apache-2.0",
   "browser": "dist/videocontext.js",
+  "main": "dist/videocontext.js",
   "keywords": [
     "video",
     "context",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.52.10",
+  "version": "0.54.0",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "videocontext",
-  "version": "0.54.0",
+  "version": "0.52.10",
   "description": "A WebGL & HTML5 graph based video composition library",
   "repository": {
     "type": "git",

--- a/src/ProcessingNodes/compositingnode.js
+++ b/src/ProcessingNodes/compositingnode.js
@@ -38,7 +38,16 @@ class CompositingNode extends ProcessingNode {
         );
         gl.clearColor(0, 0, 0, 0); // green;
         gl.clear(gl.COLOR_BUFFER_BIT);
-        gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+        if (this.inputs.length == 1) {
+            // If there is only 1 input, set the blendFunc to prioritise the SRC rgba values to ensure
+            // there is no blending of the background clearColor to a transparent SRC image i.e. no 'bleeding' of background color into transparency
+            gl.blendFunc(gl.ONE, gl.ZERO);
+        } else {
+            // If there is more than 1 input, set the blendFunc to blend the RGB separately from A
+            // We blend separately because as you stack layers in a CompositingNode, we don't want to interpolate alpha
+            // (i.e. we don't want a mid-point or a weighted average of the alpha channels)
+            gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+        }
 
         this.inputs.forEach(node => {
             if (node === undefined) return;

--- a/src/ProcessingNodes/compositingnode.js
+++ b/src/ProcessingNodes/compositingnode.js
@@ -46,7 +46,12 @@ class CompositingNode extends ProcessingNode {
             // If there is more than 1 input, set the blendFunc to blend the RGB separately from A
             // We blend separately because as you stack layers in a CompositingNode, we don't want to interpolate alpha
             // (i.e. we don't want a mid-point or a weighted average of the alpha channels)
-            gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+            gl.blendFuncSeparate(
+                gl.SRC_ALPHA,
+                gl.ONE_MINUS_SRC_ALPHA,
+                gl.ONE,
+                gl.ONE_MINUS_SRC_ALPHA
+            );
         }
 
         this.inputs.forEach(node => {

--- a/src/ProcessingNodes/compositingnode.js
+++ b/src/ProcessingNodes/compositingnode.js
@@ -38,21 +38,7 @@ class CompositingNode extends ProcessingNode {
         );
         gl.clearColor(0, 0, 0, 0); // green;
         gl.clear(gl.COLOR_BUFFER_BIT);
-        if (this.inputs.length == 1) {
-            // If there is only 1 input, set the blendFunc to prioritise the SRC rgba values to ensure
-            // there is no blending of the background clearColor to a transparent SRC image i.e. no 'bleeding' of background color into transparency
-            gl.blendFunc(gl.ONE, gl.ZERO);
-        } else {
-            // If there is more than 1 input, set the blendFunc to blend the RGB separately from A
-            // We blend separately because as you stack layers in a CompositingNode, we don't want to interpolate alpha
-            // (i.e. we don't want a mid-point or a weighted average of the alpha channels)
-            gl.blendFuncSeparate(
-                gl.SRC_ALPHA,
-                gl.ONE_MINUS_SRC_ALPHA,
-                gl.ONE,
-                gl.ONE_MINUS_SRC_ALPHA
-            );
-        }
+        gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
 
         this.inputs.forEach(node => {
             if (node === undefined) return;

--- a/src/ProcessingNodes/effectnode.js
+++ b/src/ProcessingNodes/effectnode.js
@@ -40,6 +40,7 @@ class EffectNode extends ProcessingNode {
         );
         gl.clearColor(0, 0, 0, 0); // green;
         gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.blendFunc(gl.ONE, gl.ZERO);
 
         super._render();
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,15 +9,15 @@ import { TRANSITIONTYPE } from "./ProcessingNodes/transitionnode.js";
 import { COMPOSITINGTYPE } from "./ProcessingNodes/compositingnode.js";
 
 /*
-* Utility function to compile a WebGL Vertex or Fragment shader.
-*
-* @param {WebGLRenderingContext} gl - the webgl context fo which to build the shader.
-* @param {String} shaderSource - A string of shader code to compile.
-* @param {number} shaderType - Shader type, either WebGLRenderingContext.VERTEX_SHADER or WebGLRenderingContext.FRAGMENT_SHADER.
-*
-* @return {WebGLShader} A compiled shader.
-*
-*/
+ * Utility function to compile a WebGL Vertex or Fragment shader.
+ *
+ * @param {WebGLRenderingContext} gl - the webgl context fo which to build the shader.
+ * @param {String} shaderSource - A string of shader code to compile.
+ * @param {number} shaderType - Shader type, either WebGLRenderingContext.VERTEX_SHADER or WebGLRenderingContext.FRAGMENT_SHADER.
+ *
+ * @return {WebGLShader} A compiled shader.
+ *
+ */
 export function compileShader(gl, shaderSource, shaderType) {
     let shader = gl.createShader(shaderType);
     gl.shaderSource(shader, shaderSource);
@@ -30,14 +30,14 @@ export function compileShader(gl, shaderSource, shaderType) {
 }
 
 /*
-* Create a shader program from a passed vertex and fragment shader source string.
-*
-* @param {WebGLRenderingContext} gl - the webgl context fo which to build the shader.
-* @param {WebGLShader} vertexShader - A compiled vertex shader.
-* @param {WebGLShader} fragmentShader - A compiled fragment shader.
-*
-* @return {WebGLProgram} A compiled & linkde shader program.
-*/
+ * Create a shader program from a passed vertex and fragment shader source string.
+ *
+ * @param {WebGLRenderingContext} gl - the webgl context fo which to build the shader.
+ * @param {WebGLShader} vertexShader - A compiled vertex shader.
+ * @param {WebGLShader} fragmentShader - A compiled fragment shader.
+ *
+ * @return {WebGLProgram} A compiled & linkde shader program.
+ */
 export function createShaderProgram(gl, vertexShader, fragmentShader) {
     let program = gl.createProgram();
 

--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -925,17 +925,17 @@ export default class VideoContext {
             }
 
             /*
-            * Itterate the directed acyclic graph using Khan's algorithm (KHAAAAAN!).
-            *
-            * This has highlighted a bunch of ineffencies in the rendergraph class about how its stores connections.
-            * Mainly the fact that to get inputs for a node you have to iterate the full list of connections rather than
-            * a node owning it's connections.
-            * The trade off with changing this is making/removing connections becomes more costly performance wise, but
-            * this is deffinately worth while because getting the connnections is a much more common operation.
-            *
-            * TL;DR Future matt - refactor this.
-            *
-            */
+             * Itterate the directed acyclic graph using Khan's algorithm (KHAAAAAN!).
+             *
+             * This has highlighted a bunch of ineffencies in the rendergraph class about how its stores connections.
+             * Mainly the fact that to get inputs for a node you have to iterate the full list of connections rather than
+             * a node owning it's connections.
+             * The trade off with changing this is making/removing connections becomes more costly performance wise, but
+             * this is deffinately worth while because getting the connnections is a much more common operation.
+             *
+             * TL;DR Future matt - refactor this.
+             *
+             */
             let sortedNodes = [];
             let connections = this._renderGraph.connections.slice();
             let nodes = RenderGraph.getInputlessNodes(connections);

--- a/test/integration/medianode.test.js
+++ b/test/integration/medianode.test.js
@@ -4,9 +4,9 @@ let ctx;
 require("webgl-mock");
 
 /*
-* creates a video node with provided attributes.
-* returns: the node instance and the mocked HTMLVideoElement which is controlled by the node
-*/
+ * creates a video node with provided attributes.
+ * returns: the node instance and the mocked HTMLVideoElement which is controlled by the node
+ */
 const nodeFactory = (
     vidCtx,
     attr = {},
@@ -36,20 +36,20 @@ const nodeFactory = (
 };
 
 /*
-* create a fresh video context with mocked canvas for each test
-* don't useVideoElementCache as unnecessary for these tests and would need to be patched with a mock.
-*/
+ * create a fresh video context with mocked canvas for each test
+ * don't useVideoElementCache as unnecessary for these tests and would need to be patched with a mock.
+ */
 beforeEach(() => {
     const canvas = new HTMLCanvasElement(500, 500);
     ctx = new VideoContext(canvas, undefined, { useVideoElementCache: false });
 });
 
 /*
-* These tests use nodeFactory to produce a video element and a controlling video node.
-* The tests check that interaction with the node effects the element as intended.
-* Some tested interactions require the node to have loaded. (eg updating element attributes)
-* We use the public ctx.update method to advance the videocontext timeline and trigger these updates
-*/
+ * These tests use nodeFactory to produce a video element and a controlling video node.
+ * The tests check that interaction with the node effects the element as intended.
+ * Some tested interactions require the node to have loaded. (eg updating element attributes)
+ * We use the public ctx.update method to advance the videocontext timeline and trigger these updates
+ */
 describe("medianode", () => {
     describe("volume", () => {
         it("volume setter sets volume on element", () => {


### PR DESCRIPTION
Fixes #125 

Please see the issue above for details on the bug.

This PR changes the blending function of the WebGL context used when rendering the output of Effect and Compositor Nodes. This change eliminates the black discolouration seen previously. 
The discolouration occurred because the blending function set by the destination node would cause any images with transparency to blended with the context's background, in this case, solid black.
The changes to the effect node's blend function causes its input to be blended with transparency instead of the context's background.
The same has been done for compositing nodes, but we also need to account for cases where multiple translucent sources connected to a single compositor node.