### PR TITLE
Fix effect node alpha blending

### DIFF
--- a/src/ProcessingNodes/effectnode.js
+++ b/src/ProcessingNodes/effectnode.js
@@ -40,6 +40,7 @@ class EffectNode extends ProcessingNode {
         );
         gl.clearColor(0, 0, 0, 0); // green;
         gl.clear(gl.COLOR_BUFFER_BIT);
+        gl.blendFunc(gl.ONE, gl.ZERO);
 
         super._render();
 


### PR DESCRIPTION
Fixes #125 for effect nodes only. This is still an issue when using compositor nodes.