### PR TITLE
Make webpack build mode 'development' when not running in CI pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration
   - TEST_SUITE=regression
-  - TEST_SUITE=build NODE_ENV=production
+  - TEST_SUITE=build
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - TEST_SUITE=integration
   - TEST_SUITE=regression
   - TEST_SUITE=build
+  - NODE_ENV=production
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,7 @@ env:
   - TEST_SUITE=unit
   - TEST_SUITE=integration
   - TEST_SUITE=regression
-  - TEST_SUITE=build
-  - NODE_ENV=production
+  - TEST_SUITE=build NODE_ENV=production
 branches:
   only:
     - master

--- a/webpack.commonjs2.config.js
+++ b/webpack.commonjs2.config.js
@@ -1,7 +1,9 @@
-/* eslint-disable */
+/* eslint-env node */
+
+const env = process.env.NODE_ENV;
 
 module.exports = {
-    mode: "production",
+    mode: env || "development",
     entry: __dirname + "/src/videocontext.js",
     devtool: "source-map",
     stats: { warnings: false },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
 /* eslint-env node */
 
-const env = process.env.NODE_ENV;
+const env = process.env.TEST_SUITE;
 
 module.exports = {
-    mode: env || "development",
+    mode: env === "build" ? "production" : "development",
     entry: __dirname + "/src/videocontext.js",
     devtool: "source-map",
     stats: { warnings: false },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,9 @@
-/* eslint-disable */
+/* eslint-env node */
+
+const env = process.env.NODE_ENV;
 
 module.exports = {
-    mode: "production",
+    mode: env || "development",
     entry: __dirname + "/src/videocontext.js",
     devtool: "source-map",
     stats: { warnings: false },


### PR DESCRIPTION
This PR aims to speed up the webpack build time when not running in a CI environment.

The mode `production` does a lot of great optimisation. However this comes at a cost... "time". Those optimisations are pretty much useless for development.

Environment variables config are set in the `.travis.yml` file.

- [webpack mode doc](https://webpack.js.org/concepts/mode/)
- [Travis env var doc](https://docs.travis-ci.com/user/environment-variables/)

I've also updated the ESLint config so that it is enabled but also acknowledges that this files runs in a node environment with its own set of global variables.

Couldn't test this against the Travis Pipeline but I'm fairly confident that it should work 👍 