### PR TITLE
Improve JSDoc comments for src/VideoContext.js and how options default are handled

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jsdoc": "^3.4.3",
     "path": "^0.12.7",
     "prettier": "^1.13.2",
-    "puppeteer": "^1.4.0",
+    "puppeteer": "1.11.0",
     "raw-loader": "^0.5.1",
     "sinon": "^4.2.1",
     "webgl-mock": "^0.1.7",

--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -64,14 +64,14 @@ export default class VideoContext {
         } = {}
     ) {
         this._canvas = canvas;
-        this.endOnLastSourceEnd = endOnLastSourceEnd;
+        this._endOnLastSourceEnd = endOnLastSourceEnd;
 
         this._gl = canvas.getContext(
             "experimental-webgl",
             Object.assign(
                 { preserveDrawingBuffer: true }, // can be overriden
                 webglContextAttributes,
-                { alpha: true } // Can't be overriden because it is copied last
+                { alpha: false } // Can't be overriden because it is copied last
             )
         );
         if (this._gl === null) {

--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -34,12 +34,17 @@ export default class VideoContext {
      * Initialise the VideoContext and render to the specific canvas. A 2nd parameter can be passed to the constructor which is a function that get's called if the VideoContext fails to initialise.
      *
      * @param {Canvas} canvas - the canvas element to render the output to.
-     * @param {function} initErrorCallback - a callback for if initialising the canvas failed.
-     * @param {Object} options - a nuber of custom options which can be set on the VideoContext, generally best left as default.
+     * @param {function} [initErrorCallback] - a callback for if initialising the canvas failed.
+     * @param {Object} [options] - a number of custom options which can be set on the VideoContext, generally best left as default.
+     * @param {boolean} [options.manualUpdate=false] - Make Video Context not use the updatable manager
+     * @param {boolean} [options.endOnLastSourceEnd=true] - Trigger an `ended` event when the current time goes above the duration of the composition
+     * @param {boolean} [options.useVideoElementCache=true] - Creates a pool of video element that will be all initialised at the same time. Important for mobile support
+     * @param {number} [options.videoElementCacheSize=6] - Number of video element in the pool
+     * @param {object} [options.webglContextAttributes] - A set of attributes used when getting the GL context. Alpha will always be `true`.
      *
      * @example
      * var canvasElement = document.getElementById("canvas");
-     * var ctx = new VideoContext(canvasElement, function(){console.error("Sorry, your browser dosen\'t support WebGL");});
+     * var ctx = new VideoContext(canvasElement, () => console.error("Sorry, your browser dosen\'t support WebGL"));
      * var videoNode = ctx.video("video.mp4");
      * videoNode.connect(ctx.destination);
      * videoNode.start(0);
@@ -50,37 +55,22 @@ export default class VideoContext {
     constructor(
         canvas,
         initErrorCallback,
-        options = {
-            preserveDrawingBuffer: true,
-            manualUpdate: false,
-            endOnLastSourceEnd: true,
-            useVideoElementCache: true,
-            videoElementCacheSize: 6,
-            webglContextAttributes: {
-                preserveDrawingBuffer: true,
-                alpha: false
-            }
-        }
+        {
+            manualUpdate = false,
+            endOnLastSourceEnd = true,
+            useVideoElementCache = true,
+            videoElementCacheSize = 6,
+            webglContextAttributes = {}
+        } = {}
     ) {
         this._canvas = canvas;
-        let manualUpdate = false;
-        this.endOnLastSourceEnd = true;
-        let webglContextAttributes = {
-            preserveDrawingBuffer: true,
-            alpha: false
-        };
+        this.endOnLastSourceEnd = endOnLastSourceEnd;
 
-        if ("manualUpdate" in options) manualUpdate = options.manualUpdate;
-        if ("endOnLastSourceEnd" in options) this._endOnLastSourceEnd = options.endOnLastSourceEnd;
-        if ("webglContextAttributes" in options)
-            webglContextAttributes = options.webglContextAttributes;
-
-        if (webglContextAttributes.alpha === undefined) webglContextAttributes.alpha = false;
-        if (webglContextAttributes.alpha === true) {
-            console.error("webglContextAttributes.alpha must be false for correct opeation");
-        }
-
-        this._gl = canvas.getContext("experimental-webgl", webglContextAttributes);
+        this._gl = canvas.getContext("experimental-webgl", Object.assign(
+            { preserveDrawingBuffer: true }, // can be overriden
+            webglContextAttributes,
+            { alpha: true } // Can't be overriden because it is copied last
+        ));
         if (this._gl === null) {
             console.error("Failed to intialise WebGL.");
             if (initErrorCallback) initErrorCallback();
@@ -88,11 +78,9 @@ export default class VideoContext {
         }
 
         // Initialise the video element cache
-        if (options.useVideoElementCache === undefined) options.useVideoElementCache = true;
-        this._useVideoElementCache = options.useVideoElementCache;
+        this._useVideoElementCache = useVideoElementCache;
         if (this._useVideoElementCache) {
-            if (!options.videoElementCacheSize) options.videoElementCacheSize = 5;
-            this._videoElementCache = new VideoElementCache(options.videoElementCacheSize);
+            this._videoElementCache = new VideoElementCache(videoElementCacheSize);
         }
 
         // Create a unique ID for this VideoContext which can be used in the debugger.
@@ -131,8 +119,8 @@ export default class VideoContext {
     }
 
     /**
-     * Reurns an ID assigned to the VideoContext instance. This will either be the same id as the underlying canvas element,
-     * or a uniquley generated one.
+     * Returns an ID assigned to the VideoContext instance. This will either be the same id as the underlying canvas element,
+     * or a uniquely generated one.
      */
     get id() {
         return this._id;
@@ -181,23 +169,23 @@ export default class VideoContext {
     }
 
     /**
-     * Regsiter a callback to listen to one of the following events: "stalled", "update", "ended", "content", "nocontent"
+     * Register a callback to listen to one of the following events: "stalled", "update", "ended", "content", "nocontent"
      *
-     * "stalled" happend anytime playback is stopped due to unavailbale data for playing assets (i.e video still loading)
-     * . "update" is called any time a frame is rendered to the screen. "ended" is called once plackback has finished
-     * (i.e ctx.currentTime == ctx.duration). "content" is called a the start of a time region where there is content
-     * playing out of one or more sourceNodes. "nocontent" is called at the start of any time region where the
-     * VideoContext is still playing, but there are currently no activly playing soureces.
+     * "stalled" happens anytime the playback is stopped due to buffer starvation for playing assets.
+     * "update" is called any time a frame is rendered to the screen.
+     * "ended" is called once plackback has finished (i.e ctx.currentTime == ctx.duration).
+     * "content" is called at the start of a time region where there is content playing out of one or more sourceNodes.
+     * "nocontent" is called at the start of any time region where the VideoContext is still playing, but there are currently no active playing sources.
      *
-     * @param {String} type - the event to register against ("stalled", "update", or "ended").
+     * @param {String} type - the event to register against ("stalled", "update", "ended", "content", "nocontent").
      * @param {Function} func - the callback to register.
      *
      * @example
      * var canvasElement = document.getElementById("canvas");
      * var ctx = new VideoContext(canvasElement);
-     * ctx.registerCallback("stalled", function(){console.log("Playback stalled");});
-     * ctx.registerCallback("update", function(){console.log("new frame");});
-     * ctx.registerCallback("ended", function(){console.log("Playback ended");});
+     * ctx.registerCallback("stalled", () => console.log("Playback stalled"));
+     * ctx.registerCallback("update", () => console.log("new frame"));
+     * ctx.registerCallback("ended", () => console.log("Playback ended"));
      */
     registerCallback(type, func) {
         if (!this._callbacks.has(type)) return false;
@@ -205,7 +193,7 @@ export default class VideoContext {
     }
 
     /**
-     * Remove a previously registed callback
+     * Remove a previously registered callback
      *
      * @param {Function} func - the callback to remove.
      *
@@ -214,7 +202,7 @@ export default class VideoContext {
      * var ctx = new VideoContext(canvasElement);
      *
      * //the callback
-     * var updateCallback = function(){console.log("new frame")};
+     * var updateCallback = () => console.log("new frame");
      *
      * //register the callback
      * ctx.registerCallback("update", updateCallback);
@@ -243,7 +231,7 @@ export default class VideoContext {
     /**
      * Get the canvas that the VideoContext is using.
      *
-     * @return {HTMLElement} The canvas that the VideoContext is using.
+     * @return {HTMLCanvasElement} The canvas that the VideoContext is using.
      *
      */
     get element() {
@@ -252,14 +240,7 @@ export default class VideoContext {
 
     /**
      * Get the current state.
-     *
-     * This will be either
-     *  - VideoContext.STATE.PLAYING: current sources on timeline are active
-     *  - VideoContext.STATE.PAUSED: all sources are paused
-     *  - VideoContext.STATE.STALLED: one or more sources is unable to play
-     *  - VideoContext.STATE.ENDED: all sources have finished playing
-     *  - VideoContext.STATE.BROKEN: the render graph is in a broken state
-     * @return {number} The number representing the state.
+     * @return {STATE} The number representing the state.
      *
      */
     get state() {
@@ -268,9 +249,9 @@ export default class VideoContext {
 
     /**
      * Set the progress through the internal timeline.
-     * Setting this can be used as a way to implement a scrubaable timeline.
+     * Setting this can be used as a way to implement a scrubbable timeline.
      *
-     * @param {number} currentTime - this is the currentTime to set the context to.
+     * @param {number} currentTime - this is the currentTime to set in seconds.
      *
      * @example
      * var canvasElement = document.getElementById("canvas");
@@ -314,7 +295,7 @@ export default class VideoContext {
      * videoNode.start(0);
      * videoNode.stop(10);
      * ctx.play();
-     * setTimeout(function(){console.log(ctx.currentTime);},1000); //should print roughly 1.0
+     * setTimeout(() => console.log(ctx.currentTime),1000); //should print roughly 1.0
      *
      */
     get currentTime() {
@@ -358,7 +339,7 @@ export default class VideoContext {
      *
      * This proprety is read-only and there can only ever be one destination node. Other nodes can connect to this but you cannot connect this node to anything.
      *
-     * @return {DestinationNode} A graph node represnting the canvas to display the content on.
+     * @return {DestinationNode} A graph node representing the canvas to display the content on.
      * @example
      * var canvasElement = document.getElementById("canvas");
      * var ctx = new VideoContext(canvasElement);
@@ -410,7 +391,7 @@ export default class VideoContext {
     }
 
     /**
-     * Set the volume of all VideoNode's created in the VideoContext.
+     * Set the volume of all MediaNode created in the VideoContext.
      * @param {number} volume - the volume to apply to the video nodes.
      */
     set volume(vol) {
@@ -423,7 +404,7 @@ export default class VideoContext {
     }
 
     /**
-     *  Return the current volume of the video context.
+     * Return the current volume of the video context.
      * @return {number} A value representing the volume. 1.0 by default.
      */
     get volume() {
@@ -443,7 +424,7 @@ export default class VideoContext {
      */
     play() {
         console.debug("VideoContext - playing");
-        //Initialise the video elemnt cache
+        //Initialise the video element cache
         if (this._videoElementCache) this._videoElementCache.init();
         // set the state.
         this._state = VideoContext.STATE.PLAYING;
@@ -461,7 +442,7 @@ export default class VideoContext {
      * videoNode.stop(20);
      * ctx.currentTime = 10; // seek 10 seconds in
      * ctx.play();
-     * setTimeout(function(){ctx.pause();}, 1000); //pause playback after roughly one second.
+     * setTimeout(() => ctx.pause(), 1000); //pause playback after roughly one second.
      */
     pause() {
         console.debug("VideoContext - pausing");
@@ -472,22 +453,16 @@ export default class VideoContext {
     /**
      * Create a new node representing a video source
      *
-     * @param {string|Video} - The URL or video element to create the video from.
-     * @sourceOffset {number} - Offset into the start of the source video to start playing from.
-     * @preloadTime {number} - How many seconds before the video is to be played to start loading it.
-     * @videoElementAttributes {Object} - A dictionary of attributes to map onto the underlying video element.
+     * @param {string|HTMLVideoElement|MediaStream} - The URL or video element to create the video from.
+     * @param {number} [sourceOffset=0] - Offset into the start of the source video to start playing from.
+     * @param {number} [preloadTime=4] - How many seconds before the video is to be played to start loading it.
+     * @param {Object} [videoElementAttributes] - A dictionary of attributes to map onto the underlying video element.
      * @return {VideoNode} A new video node.
      *
      * @example
      * var canvasElement = document.getElementById("canvas");
      * var ctx = new VideoContext(canvasElement);
-     * var videoNode = ctx.video("video.mp4");
-     *
-     * @example
-     * var canvasElement = document.getElementById("canvas");
-     * var videoElement = document.getElementById("video");
-     * var ctx = new VideoContext(canvasElement);
-     * var videoNode = ctx.video(videoElement);
+     * var videoNode = ctx.video("bigbuckbunny.mp4");
      */
     video(src, sourceOffset = 0, preloadTime = 4, videoElementAttributes = {}) {
         let videoNode = new VideoNode(
@@ -505,6 +480,19 @@ export default class VideoContext {
         return videoNode;
     }
 
+    /**
+     * Create a new node representing an audio source
+     * @param {string|HTMLAudioElement|MediaStream} src - The url or audio element to create the audio node from.
+     * @param {number} [sourceOffset=0] - Offset into the start of the source audio to start playing from.
+     * @param {number} [preloadTime=4] - How long before a node is to be displayed to attmept to load it.
+     * @param {Object} [imageElementAttributes] - Any attributes to be given to the underlying image element.
+     * @return {AudioNode} A new audio node.
+     *
+     * @example
+     * var canvasElement = document.getElementById("canvas");
+     * var ctx = new VideoContext(canvasElement);
+     * var audioNode = ctx.audio("ziggystardust.mp3");
+     */
     audio(src, sourceOffset = 0, preloadTime = 4, audioElementAttributes = {}) {
         let audioNode = new AudioNode(
             src,
@@ -522,19 +510,19 @@ export default class VideoContext {
     }
 
     /**
-     * @depricated
+     * @deprecated
      */
     createVideoSourceNode(src, sourceOffset = 0, preloadTime = 4, videoElementAttributes = {}) {
-        this._depricate(
-            "Warning: createVideoSourceNode will be depricated in v1.0, please switch to using VideoContext.video()"
+        this._deprecate(
+            "Warning: createVideoSourceNode will be deprecated in v1.0, please switch to using VideoContext.video()"
         );
         return this.video(src, sourceOffset, preloadTime, videoElementAttributes);
     }
 
     /**
      * Create a new node representing an image source
-     * @param {string|Image} src - The url or image element to create the image node from.
-     * @param {number} [preloadTime] - How long before a node is to be displayed to attmept to load it.
+     * @param {string|Image|ImageBitmap} src - The url or image element to create the image node from.
+     * @param {number} [preloadTime=4] - How long before a node is to be displayed to attmept to load it.
      * @param {Object} [imageElementAttributes] - Any attributes to be given to the underlying image element.
      * @return {ImageNode} A new image node.
      *
@@ -563,11 +551,11 @@ export default class VideoContext {
     }
 
     /**
-     * @depricated
+     * @deprecated
      */
     createImageSourceNode(src, sourceOffset = 0, preloadTime = 4, imageElementAttributes = {}) {
-        this._depricate(
-            "Warning: createImageSourceNode will be depricated in v1.0, please switch to using VideoContext.image()"
+        this._deprecate(
+            "Warning: createImageSourceNode will be deprecated in v1.0, please switch to using VideoContext.image()"
         );
         return this.image(src, sourceOffset, preloadTime, imageElementAttributes);
     }
@@ -584,11 +572,11 @@ export default class VideoContext {
     }
 
     /**
-     * @depricated
+     * @deprecated
      */
     createCanvasSourceNode(canvas, sourceOffset = 0, preloadTime = 4) {
-        this._depricate(
-            "Warning: createCanvasSourceNode will be depricated in v1.0, please switch to using VideoContext.canvas()"
+        this._deprecate(
+            "Warning: createCanvasSourceNode will be deprecated in v1.0, please switch to using VideoContext.canvas()"
         );
         return this.canvas(canvas, sourceOffset, preloadTime);
     }
@@ -605,11 +593,11 @@ export default class VideoContext {
     }
 
     /**
-     * @depricated
+     * @deprecated
      */
     createEffectNode(definition) {
-        this._depricate(
-            "Warning: createEffectNode will be depricated in v1.0, please switch to using VideoContext.effect()"
+        this._deprecate(
+            "Warning: createEffectNode will be deprecated in v1.0, please switch to using VideoContext.effect()"
         );
         return this.effect(definition);
     }
@@ -683,11 +671,11 @@ export default class VideoContext {
     }
 
     /**
-     * @depricated
+     * @deprecated
      */
     createCompositingNode(definition) {
-        this._depricate(
-            "Warning: createCompositingNode will be depricated in v1.0, please switch to using VideoContext.compositor()"
+        this._deprecate(
+            "Warning: createCompositingNode will be deprecated in v1.0, please switch to using VideoContext.compositor()"
         );
         return this.compositor(definition);
     }
@@ -777,11 +765,11 @@ export default class VideoContext {
     }
 
     /**
-     * @depricated
+     * @deprecated
      */
     createTransitionNode(definition) {
-        this._depricate(
-            "Warning: createTransitionNode will be depricated in v1.0, please switch to using VideoContext.transition()"
+        this._deprecate(
+            "Warning: createTransitionNode will be deprecated in v1.0, please switch to using VideoContext.transition()"
         );
         return this.transition(definition);
     }
@@ -990,7 +978,7 @@ export default class VideoContext {
         this._timelineCallbacks = [];
     }
 
-    _depricate(msg) {
+    _deprecate(msg) {
         console.log(msg);
     }
 
@@ -1006,17 +994,24 @@ export default class VideoContext {
     }
 }
 
-//playing - all sources are active
-//paused - all sources are paused
-//stalled - one or more sources is unable to play
-//ended - all sources have finished playing
-//broken - the render graph is in a broken state
-VideoContext.STATE = {};
-VideoContext.STATE.PLAYING = 0;
-VideoContext.STATE.PAUSED = 1;
-VideoContext.STATE.STALLED = 2;
-VideoContext.STATE.ENDED = 3;
-VideoContext.STATE.BROKEN = 4;
+/**
+ * Video Context States
+ * @readonly
+ * @typedef {Object} STATE
+ * @property {number} STATE.PLAYING - All sources are active
+ * @property {number} STATE.PAUSED - All sources are paused
+ * @property {number} STATE.STALLED - One or more sources is unable to play
+ * @property {number} STATE.ENDED - All sources have finished playing
+ * @property {number} STATE.BROKEN - The render graph is in a broken state
+ */
+const STATE = Object.freeze({
+    PLAYING: 0,
+    PAUSED: 1,
+    STALLED: 2,
+    ENDED: 3,
+    BROKEN: 4
+});
+VideoContext.STATE = STATE;
 
 VideoContext.visualiseVideoContextTimeline = visualiseVideoContextTimeline;
 VideoContext.visualiseVideoContextGraph = visualiseVideoContextGraph;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,6 +1772,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -5004,10 +5011,10 @@ progress@^1.1.8:
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
   integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
 
-progress@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
-  integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -5086,19 +5093,19 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-puppeteer@^1.4.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.10.0.tgz#e3005f1251c2feae0e10c0f7a35afbcd56589ceb"
-  integrity sha512-3i28X/ucX8t3eL4TZA60FLMOQNKqudFSOGDHr0cT7T4dE027CrcS885aAqjdxNybhMPliM5yImNsKJ6SQrPzhw==
+puppeteer@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
+  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
   dependencies:
-    debug "^3.1.0"
+    debug "^4.1.0"
     extract-zip "^1.6.6"
     https-proxy-agent "^2.2.1"
     mime "^2.0.3"
-    progress "^2.0.0"
+    progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
-    ws "^5.1.1"
+    ws "^6.1.0"
 
 qs@~2.3.3:
   version "2.3.3"
@@ -6482,10 +6489,17 @@ write@^0.2.1:
   dependencies:
     mkdirp "^0.5.1"
 
-ws@^5.1.1, ws@^5.2.0:
+ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.1.0:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.3.tgz#d2d2e5f0e3c700ef2de89080ebc0ac6e1bf3a72d"
+  integrity sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
I noticed that the way that options default were handled could be a bit problematic.

Essentially it is currently leveraging the ES6 default parameter feature. The big problem is that if you give an option hash that has only one of the option defined. All the other defaults will be lost.
With this new approach we now take advantage of destructuring and default parameters.

I have also created a `VideoContext.EVENTS` hash that is aligned with `VideoContext.STATE`.

And last but not least, I have updated and fix some of the JSDoc comments. It still isn't perfect but I feel like that already hugely improve documentation.