### PR TITLE
Add method to register custom source node type

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,50 @@ canvasNode.stop(4);
 
 ```
 
+### CustomSourceNode
+
+Sometimes using the pre-built node is just not enough.
+You can create your own source nodes that host more logic and let you hook into the VideoContext Node API easily.
+
+View below a custom source node that can now play an HLS VOD.
+
+```JavaScript
+
+import Hls from "hls.js;
+
+class HLSNode extends VideoNode {
+    constructor(src, gl, renderGraph, currentTime, playbackRate, sourceOffset, preloadTime, hlsOptions = {}) {
+
+        this._src = src;
+        const video = document.createElement("video");
+        this.hls = new Hls(hlsOptions);
+        this.hls.attachVideo(video);
+
+        super(video, gl, renderGraph, currentTime, playbackRate, sourceOffset, preloadTime);
+
+        this._displayName = "HLSNode";
+        this._elementType = "hls";
+    }
+
+    _load() {
+        this.hls.loadSource(this._src);
+        this.hls.on(Hls.Events.MANIFEST_PARSED, () => {
+            this._ready = true;
+            this._triggerCallbacks("loaded");
+        });
+    }
+
+    destroy() {
+        if (this.hls) {
+            this.hls.destroy();
+        }
+        super.destroy();
+    }
+}
+
+```
+
+Another use case for custom node types would be to play GIFs. The custom node would be in charge of decode the GIF frames and paint them on a canvas depending on the `_update` calls from `VideoContext`.
 
 ### EffectNode
 An EffectNode is the simplest form of processing node. It's built from a definition object, which is a combination of fragment shader code, vertex shader code, input descriptions, and property descriptions. There are a number of common operations available as node descriptions accessible as static properties on the VideoContext at VideoContext.DESCRIPTIONS.*

--- a/src/SourceNodes/nodes.js
+++ b/src/SourceNodes/nodes.js
@@ -1,0 +1,17 @@
+import AudioNode from "./audionode";
+import CanvasNode from "./canvasnode";
+import ImageNode from "./imagenode";
+import MediaNode from "./medianode";
+import SourceNode from "./sourcenode";
+import VideoNode from "./videonode";
+
+const NODES = {
+    AudioNode,
+    CanvasNode,
+    ImageNode,
+    MediaNode,
+    SourceNode,
+    VideoNode
+};
+
+export default NODES;

--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -690,7 +690,9 @@ export default class VideoContext {
      * @param  {...any} options
      */
     customSourceNode(CustomSourceNode, src, ...options) {
-        return new CustomSourceNode(src, this._gl, this._renderGraph, this._currentTime, ...options);
+        const customSourceNode = new CustomSourceNode(src, this._gl, this._renderGraph, this._currentTime, ...options);
+        this._sourceNodes.push(customSourceNode);
+        return customSourceNode;
     }
 
     /**

--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -10,6 +10,7 @@ import {
     snapshot,
     generateRandomId
 } from "./utils.js";
+import NODES from "./SourceNodes/nodes.js";
 import VideoNode, { VIDEOTYPE } from "./SourceNodes/videonode.js";
 import AudioNode from "./SourceNodes/audionode.js";
 import ImageNode from "./SourceNodes/imagenode.js";
@@ -683,6 +684,16 @@ export default class VideoContext {
     }
 
     /**
+     * Instanciate a custom built source node
+     * @param {SourceNode} CustomSourceNode
+     * @param {Object} src
+     * @param  {...any} options
+     */
+    customSourceNode(CustomSourceNode, src, ...options) {
+        return new CustomSourceNode(src, this._gl, this._renderGraph, this._currentTime, ...options);
+    }
+
+    /**
      * @depricated
      */
     createCompositingNode(definition) {
@@ -996,6 +1007,10 @@ export default class VideoContext {
 
     static get DEFINITIONS() {
         return DEFINITIONS;
+    }
+
+    static get NODES() {
+        return NODES;
     }
 
     /**


### PR DESCRIPTION
This PR follows up on the issue #115 and will help achieve #19 without increasing the video context footprint.

On the issue we were talking about creating a factory function where we can pass a video context instance. After thinking about it a bit further I found a few issues with that approach.

Essentially when creating a node we rely on some vc internal

- `_gl`
- `_renderGraph`
- `_currentTime`

By going with the approach that I propose in this PR I feel like the custom types will be less likely to break in case of a breaking change in the naming of one of those internal properties.

I could not find any use case to create a custom node type that is not a source as `EffectNode` are already super generic and let you pretty much do everything you want by giving a custom definition when you instantiate them.

However for sources I could thinking of the following use cases:

- Playing an HLS source and you want the ready event to be triggered when the manifest has been downloaded and some content is available in the video
- Same goes with DASH
- Decode a GIF (using something like `libgif` on npm) and display the GIF frames by hooking into the `_update` function 
- Interpolate some animations on a CanvasNode that rely on time  
- ...

I feel like I am missing documentation and a proper `SourceNode` interface.
Any suggestions as to where I could add that?