### PR TITLE
Bugfix: Preload audio playing

### DIFF
--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -88,7 +88,7 @@ class MediaNode extends SourceNode {
                  * Get a cached video element and also pass this instance so the
                  * cache can access the current play state.
                  */
-                this._element = this._mediaElementCache.get(this);
+                this._element = this._mediaElementCache.getElementAndLinkToNode(this);
             } else {
                 this._element = document.createElement(this._elementType);
                 this._element.setAttribute("crossorigin", "anonymous");
@@ -201,7 +201,8 @@ class MediaNode extends SourceNode {
                 this._element.removeAttribute(key);
             }
             // Unlink this form the cache, freeing up the element for another media node
-            if (this._mediaElementCache) this._mediaElementCache.unlink(this._element);
+            if (this._mediaElementCache)
+                this._mediaElementCache.unlinkNodeFromElement(this._element);
             this._element = undefined;
             if (!this._mediaElementCache) delete this._element;
         }

--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -84,7 +84,11 @@ class MediaNode extends SourceNode {
         // If the user hasn't supplied an element, videocontext is responsible for the element
         if (this._isResponsibleForElementLifeCycle) {
             if (this._mediaElementCache) {
-                this._element = this._mediaElementCache.get();
+                /**
+                 * Get a cached video element and also pass this instance so the
+                 * cache can access the current play state.
+                 */
+                this._element = this._mediaElementCache.get(this);
             } else {
                 this._element = document.createElement(this._elementType);
                 this._element.setAttribute("crossorigin", "anonymous");
@@ -196,6 +200,8 @@ class MediaNode extends SourceNode {
             for (let key in this._attributes) {
                 this._element.removeAttribute(key);
             }
+            // Unlink this form the cache, freeing up the element for another media node
+            if (this._mediaElementCache) this._mediaElementCache.unlink(this._element);
             this._element = undefined;
             if (!this._mediaElementCache) delete this._element;
         }

--- a/src/videoelementcache.js
+++ b/src/videoelementcache.js
@@ -3,17 +3,17 @@ import { mediaElementHasSource } from "./utils";
 
 class VideoElementCache {
     constructor(cache_size = 3) {
-        this._elements = [];
-        this._elementsInitialised = false;
+        this._cacheItems = [];
+        this._cacheItemsInitialised = false;
         for (let i = 0; i < cache_size; i++) {
             // Create a video element and cache
-            this._elements.push(new VideoElementCacheItem());
+            this._cacheItems.push(new VideoElementCacheItem());
         }
     }
 
     init() {
-        if (!this._elementsInitialised) {
-            for (let cacheItem of this._elements) {
+        if (!this._cacheItemsInitialised) {
+            for (let cacheItem of this._cacheItems) {
                 try {
                     cacheItem.element.play().then(
                         () => {
@@ -31,7 +31,7 @@ class VideoElementCache {
                 }
             }
         }
-        this._elementsInitialised = true;
+        this._cacheItemsInitialised = true;
     }
 
     /**
@@ -42,7 +42,7 @@ class VideoElementCache {
      */
     getElementAndLinkToNode(mediaNode) {
         // Try and get an already intialised element.
-        for (let cacheItem of this._elements) {
+        for (let cacheItem of this._cacheItems) {
             // For some reason an uninitialised videoElement has its sr attribute set to the windows href. Hence the below check.
             if (!mediaElementHasSource(cacheItem.element)) {
                 // attach node to the element
@@ -55,8 +55,8 @@ class VideoElementCache {
             "No available video element in the cache, creating a new one. This may break mobile, make your initial cache larger."
         );
         let cacheItem = new VideoElementCacheItem(mediaNode);
-        this._elements.push(cacheItem);
-        this._elementsInitialised = false;
+        this._cacheItems.push(cacheItem);
+        this._cacheItemsInitialised = false;
         return cacheItem.element;
     }
 
@@ -66,7 +66,7 @@ class VideoElementCache {
      * @param {VideoElement} element The element to unlink from any media nodes
      */
     unlinkNodeFromElement(element) {
-        for (let cacheItem of this._elements) {
+        for (let cacheItem of this._cacheItems) {
             // Unlink the node from the element
             if (element === cacheItem._element) {
                 cacheItem.unlinkNode();
@@ -75,12 +75,12 @@ class VideoElementCache {
     }
 
     get length() {
-        return this._elements.length;
+        return this._cacheItems.length;
     }
 
     get unused() {
         let count = 0;
-        for (let cacheItem of this._elements) {
+        for (let cacheItem of this._cacheItems) {
             // For some reason an uninitialised videoElement has its sr attribute set to the windows href. Hence the below check.
             if (!mediaElementHasSource(cacheItem.element)) count += 1;
         }

--- a/src/videoelementcache.js
+++ b/src/videoelementcache.js
@@ -40,14 +40,14 @@ class VideoElementCache {
      *
      * @param {Object} mediaNode A `MediaNode` instance
      */
-    get(mediaNode) {
+    getElementAndLinkToNode(mediaNode) {
         // Try and get an already intialised element.
-        for (let elementItem of this._elements) {
+        for (let cacheItem of this._elements) {
             // For some reason an uninitialised videoElement has its sr attribute set to the windows href. Hence the below check.
-            if (!mediaElementHasSource(elementItem.element)) {
+            if (!mediaElementHasSource(cacheItem.element)) {
                 // attach node to the element
-                elementItem.linkNode(mediaNode);
-                return elementItem.element;
+                cacheItem.linkNode(mediaNode);
+                return cacheItem.element;
             }
         }
         // Fallback to creating a new element if none exist or are available
@@ -65,7 +65,7 @@ class VideoElementCache {
      *
      * @param {VideoElement} element The element to unlink from any media nodes
      */
-    unlink(element) {
+    unlinkNodeFromElement(element) {
         for (let cacheItem of this._elements) {
             // Unlink the node from the element
             if (element === cacheItem._element) {

--- a/src/videoelementcacheitem.js
+++ b/src/videoelementcacheitem.js
@@ -39,7 +39,7 @@ class VideoElementCacheItem {
     }
 
     isPlaying() {
-        return this._node._state === SOURCENODESTATE.playing;
+        return this._node && this._node._state === SOURCENODESTATE.playing;
     }
 }
 

--- a/src/videoelementcacheitem.js
+++ b/src/videoelementcacheitem.js
@@ -1,0 +1,46 @@
+import { SOURCENODESTATE } from "./SourceNodes/sourcenode";
+
+/**
+ * A video element item created and managed by the `VideoElementCache`.
+ *
+ * This creates and stores a `<video />` element, which is assigned
+ * to a `MediaNode` by the `VideoElementCache` for playback. Once
+ * playback has completed the `MediaNode` association will be removed
+ * and potentially replaced with another.
+ */
+class VideoElementCacheItem {
+    constructor(node = null) {
+        this._element = this._createElement();
+        this._node = node;
+    }
+
+    _createElement() {
+        let videoElement = document.createElement("video");
+        videoElement.setAttribute("crossorigin", "anonymous");
+        videoElement.setAttribute("webkit-playsinline", "");
+        videoElement.setAttribute("playsinline", "");
+        return videoElement;
+    }
+
+    get element() {
+        return this._element;
+    }
+
+    set element(element) {
+        this._element = element;
+    }
+
+    linkNode(node) {
+        this._node = node;
+    }
+
+    unlinkNode() {
+        this._node = null;
+    }
+
+    isPlaying() {
+        return this._node._state === SOURCENODESTATE.playing;
+    }
+}
+
+export default VideoElementCacheItem;


### PR DESCRIPTION
This fixes (when released) https://github.com/bbc/VideoContext/issues/86, where the video/audio node plays audio when preloading.

You can see/hear the issue here - https://codesandbox.io/embed/priceless-moser-8cyys

As [mentioned](https://github.com/bbc/VideoContext/issues/86#issuecomment-457143504), this appears to be caused by the [removal of the `pause`](https://github.com/bbc/VideoContext/commit/5137bee0961ccca098f88a2adb0f83a8b7bf5043) immediately after the `VideoElementCache` plays the video element.

Reverting this reintroduced https://github.com/bbc/VideoContext/pull/54, so the solution was to only pause the element if its associated video/audio node is not in the `playing` state.


## More Details

A `VideoElementCacheItem` class has been created so a relationship ("link") between a cached video element and the `MediaNode` it is currently playing can be established.

Now, the `VideoElementCache` can check if the video should remain playing before attempting to pause it, getting around https://github.com/bbc/VideoContext/pull/54.


## Potential issues

There was one unexpected consequences to this fix, where the [`sourceOffset`](https://github.com/bbc/VideoContext/blob/develop/src/videocontext.js#L453) calculation changes:

### Previously:

If the `sourceOffset` = `10` and the `start` = `5`, e.g.

```js
var videoNode = vc.video('./media.mp4', 10, 5);
    videoNode.connect(vc.destination);
    videoNode.start(5);
    videoNode.stop(15);
```

The video will be visible at `5` seconds on the VideoContext timeline, but the actual media's `currentTime` will be `15` seconds, so the offset would be `start` + `sourceOffset`.

### Now:

Using the same setup as above, the video will be visible at `5` seconds on the VideoContext timeline and the actual media's `currentTime` will be `10` seconds, so equal to the `sourceOffset` value.

This change seems to be more what I'd expect, but can anyone confirm this is OK?