### PR TITLE
Pass node constructors to custom source nodes

### DIFF
--- a/src/videocontext.js
+++ b/src/videocontext.js
@@ -678,7 +678,8 @@ export default class VideoContext {
             this._gl,
             this._renderGraph,
             this._currentTime,
-            ...options
+            ...options,
+            NODES
         );
         this._sourceNodes.push(customSourceNode);
         return customSourceNode;


### PR DESCRIPTION
## Description
This change passes the list of node constructors to custom source nodes.

## Motivation 
The purpose of this is to allow publishers of custom source nodes which extend VideoContext nodes to not include VideoContext in their bundled code. A mismatch between the package's version and the consumer's version could lead to two different versions of VideoContext being included in the consumer's bundle. 

## Example:
**Package:**
```
export function MyCustomNode(src, gl, renderGraph, currentTime, options, NODES) {
// Doesn't need to import VideoContext to extend a node
  class CustomNode extends NODES.CanvasNode {
    ...
  }

  return new CustomNode(src, gl, renderGraph, currentTime, options);
}
```

**Consumer:**

```
import VideoContext from "videocontext";
import MyCustomNode from "my-custom-vc-node";
const node = MyCustomNode();
```

The nodes being at the end of the argument list is a little annoying because you can't use rest syntax to pass the args to the class but it keeps this change backwards-compatible.