### PR TITLE
Fix black screen before play btn clicked

### DIFF
--- a/src/SourceNodes/medianode.js
+++ b/src/SourceNodes/medianode.js
@@ -94,6 +94,10 @@ class MediaNode extends SourceNode {
                 this._element.setAttribute("crossorigin", "anonymous");
                 this._element.setAttribute("webkit-playsinline", "");
                 this._element.setAttribute("playsinline", "");
+                // This seems necessary to allow using video as a texture. See:
+                // https://bugs.chromium.org/p/chromium/issues/detail?id=898550
+                // https://github.com/pixijs/pixi.js/issues/5996
+                this._element.preload = "auto";
                 this._playbackRateUpdated = true;
             }
             this._element.volume = this._attributes.volume;

--- a/src/videoelementcacheitem.js
+++ b/src/videoelementcacheitem.js
@@ -19,6 +19,10 @@ class VideoElementCacheItem {
         videoElement.setAttribute("crossorigin", "anonymous");
         videoElement.setAttribute("webkit-playsinline", "");
         videoElement.setAttribute("playsinline", "");
+        // This seems necessary to allow using video as a texture. See:
+        // https://bugs.chromium.org/p/chromium/issues/detail?id=898550
+        // https://github.com/pixijs/pixi.js/issues/5996
+        videoElement.preload = "auto";
         return videoElement;
     }
 


### PR DESCRIPTION
This seems necessary to allow using video as a texture. See:
https://bugs.chromium.org/p/chromium/issues/detail?id=898550
https://github.com/pixijs/pixi.js/issues/5996